### PR TITLE
Sanitizer ci

### DIFF
--- a/.github/workflows/sanitizer-ci.yml
+++ b/.github/workflows/sanitizer-ci.yml
@@ -2,7 +2,7 @@ name: Sanitizer-Build
 
 on:
   schedule:
-    - cron: "0 4 * * 5"
+    - cron: "0 4 * * 6"
   workflow_dispatch:
     branches:
     - sanitizer-ci


### PR DESCRIPTION
I have a version of sanitizer CI done for polkadot-light-client
- runs a build, each with one of four flags:  ASAN (address), LSAN (leak), TSAN (thread), and USAN (undefined)
- the MSAN flag is not used, as neither gcc nor clang support it.
- the builds are run using gcc (no clang)
- LSAN and USAN both build and test with no errors.  We are using per-flag Conan data cache:  with no cache the build took 32 min 8 sec.  After cache was built, 13 min 11 sec.
- TSAN and ASAN both build fine, but fail in test #3 (test_hex)
- the build is scheduled to run weekly, every Friday at 04:00 UTC.  In the future, we may choose to run it on the weekend, or early Monday morning

However, I have not yet gotten a scheduled run to happen.  I suspect in might have to do with this CI not being in the master branch.  
I can run it OK, via an explicit call, `gh workflow run 'Sanitizer-Build' --ref sanitizer-ci`. 
I have also read a bunch online, about how scheduled workflow jobs are not always 100% reliable.
I have tried several times, CI has not yet been triggered.

So, two choices (I don't want to burn so much more time on this)
- go ahead and merge this into master (if you approve the PR), and see if the cron job runs next Friday (I can change to Saturday, 04:00 UTC, before merge). It should have no effect on any production code (seems to do nothing at all, that's the problem)
- maybe one of you might have an idea of what wrong in the script.  The cron string itself `- cron: "0 4 * * 5"` checks out fine in online verifier tool: https://crontab.guru/#0_4_*_*_5